### PR TITLE
kde-apps.bbclass, kde-plasma.bbclass: Use PV for SRC_URI URL

### DIFF
--- a/classes/kde-apps.bbclass
+++ b/classes/kde-apps.bbclass
@@ -2,6 +2,6 @@ inherit kde-base
 
 KDE_APP_VERSION = "15.08.3"
 
-SRC_URI = "http://download.kde.org/stable/applications/${KDE_APP_VERSION}/src/${BPN}-${PV}.tar.xz"
+SRC_URI = "http://download.kde.org/stable/applications/${PV}/src/${BPN}-${PV}.tar.xz"
 
 RRECOMMENDS_${PN} += "qtbase-plugins"

--- a/classes/kde-plasma.bbclass
+++ b/classes/kde-plasma.bbclass
@@ -2,4 +2,4 @@ inherit kde-base
 
 PLASMA_VERSION = "5.4.3"
 
-SRC_URI = "http://download.kde.org/stable/plasma/${PLASMA_VERSION}/${BPN}-${PV}.tar.xz"
+SRC_URI = "http://download.kde.org/stable/plasma/${PV}/${BPN}-${PV}.tar.xz"


### PR DESCRIPTION
The Plasma and KDE applications use the same version for the package
and the URL.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>