### PR TITLE
kmix: initial add 15.12.0

### DIFF
--- a/recipes-kde/apps/kmix/files/0001-fix-build-with-QT_NO_SESSIONMANAGER-set.patch
+++ b/recipes-kde/apps/kmix/files/0001-fix-build-with-QT_NO_SESSIONMANAGER-set.patch
@@ -1,0 +1,26 @@
+--- a/apps/KMixApp.cpp	2016-06-07 16:48:58.967601212 +0200
++++ b/apps/KMixApp.cpp	2016-06-07 16:49:47.720048427 +0200
+@@ -80,7 +80,11 @@
+ 	 */
+ 	creationLock.lock();
+ 
++#ifndef QT_NO_SESSIONMANAGER
+ 	bool restore = isSessionRestored(); // && KMainWindow::canBeRestored(0);
++#else
++	bool restore = false;
++#endif
+ 	kDebug() << "Starting KMix using kepvisibility=" << hasArgKeepvisibility << ", failsafe=" << reset << ", sessionRestore=" << restore;
+ 	int createCount = 0;
+ 	if (restore)
+--- a/apps/kmix.cpp	2016-06-07 16:50:51.464632922 +0200
++++ b/apps/kmix.cpp	2016-06-07 16:50:24.112382155 +0200
+@@ -116,9 +116,11 @@
+ 		recreateGUI(false, QString(), true, reset);
+ 	}
+ 
++#ifndef QT_NO_SESSIONMANAGER
+ 	if (!kapp->isSessionRestored() ) // done by the session manager otherwise
++#endif
+ 	setInitialSize();
+ 
+ 	fixConfigAfterRead();

--- a/recipes-kde/apps/kmix/kmix.bb
+++ b/recipes-kde/apps/kmix/kmix.bb
@@ -1,0 +1,52 @@
+SUMMARY = "KDE's audio mixer"
+LICENSE = "GPLv2 & GFDL-1.2 & LGPLv2"
+LIC_FILES_CHKSUM = " \
+    file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+    file://COPYING.DOC;md5=24ea4c7092233849b4394699333b5c56 \
+    file://COPYING.LIB;md5=5f30f0716dfdd0d91eb439ebec522ec2 \
+"
+
+inherit kde-apps
+
+DEPENDS += " \
+    alsa-lib \
+    libcanberra \
+    \
+    kconfigwidgets \
+    kdbusaddons \
+    kdelibs4support \
+    kglobalaccel \
+    ki18n \
+    kiconthemes \
+    kxmlgui \
+    plasma-framework \
+"
+
+PACKAGECONFIG = "pulseaudio"    
+PACKAGECONFIG[pulseaudio] = ",,pulseaudio"
+
+PV = "${KDE_APP_VERSION}"
+SRC_URI[md5sum] = "f9d015862b40c9bb28307233ee012bd8"
+SRC_URI[sha256sum] = "e0e3ca3dac5605faaf7b447288675f557e1fd4205574885e2c1bfb205f37da31"
+
+SRC_URI += "file://0001-fix-build-with-QT_NO_SESSIONMANAGER-set.patch"
+
+EXTRA_OECMAKE += "-DKMIX_KF5_BUILD=1"
+
+FILES_SOLIBSDEV = ""
+
+FILES_${PN} += " \
+    ${datadir}/k*5 \
+    ${datadir}/plasma \
+    ${datadir}/icons \
+    ${datadir}/dbus-1 \
+    \
+    ${libdir}/libkdeinit5*.so \
+    ${OE_QMAKE_PATH_PLUGINS} \
+"
+
+FILES_${PN}-dbg += " \
+    ${OE_QMAKE_PATH_PLUGINS}/.debug \
+    ${OE_QMAKE_PATH_PLUGINS}/plasma/.debug \
+    ${OE_QMAKE_PATH_PLUGINS}/plasma/dataengine/.debug \
+"


### PR DESCRIPTION
KMix is KDE's audio mixer, and has recently been ported to
KDE Frameworks 5.

Signed-off-by: Manuel Bachmann <manuel.bachmann@iot.bzh>