### PR TITLE
plasma-workspace: Don't assume Qt5 binaries are installed in $bindir/qt5

### DIFF
--- a/recipes-kde/plasma/tier3/plasma-workspace/files/0003-startkde-add-meta-qt5-standard-binary-path-to-PATH.patch
+++ b/recipes-kde/plasma/tier3/plasma-workspace/files/0003-startkde-add-meta-qt5-standard-binary-path-to-PATH.patch
@@ -22,7 +22,7 @@ index 046543e..2663348 100644
  #
  
 +# meta-qt5 specific
-+PATH=$PATH:@CMAKE_INSTALL_FULL_BINDIR@/qt5; export PATH
++PATH=$PATH:@OE_QMAKE_PATH_QT_BINS@; export PATH
 +
  # When the X server dies we get a HUP signal from xinit. We must ignore it
  # because we still need to do some cleanup.

--- a/recipes-kde/plasma/tier3/plasma-workspace/files/0006-startplasmacompositor-align-qt5-bin-path.patch
+++ b/recipes-kde/plasma/tier3/plasma-workspace/files/0006-startplasmacompositor-align-qt5-bin-path.patch
@@ -34,7 +34,7 @@ index 5bcf26a..6252d79 100644
 -fi
 +
 +# meta-qt5 specific
-+qdbus=@CMAKE_INSTALL_FULL_BINDIR@/qt5/qdbus
++qdbus=@OE_QMAKE_PATH_QT_BINS@/qdbus
  
  # We need to create config folder so we can write startupconfigkeys
  if [  ${XDG_CONFIG_HOME} ]; then
@@ -43,7 +43,7 @@ index 5bcf26a..6252d79 100644
  
  # TODO: Use GenericConfigLocation once we depend on Qt 5.4
 -scriptpath=`qtpaths --paths ConfigLocation | tr ':' '\n' | sed 's,$,/plasma-workspace,g'`
-+scriptpath=`@CMAKE_INSTALL_FULL_BINDIR@/qt5/qtpaths --paths ConfigLocation | tr ':' '\n' | sed 's,$,/plasma-workspace,g'`
++scriptpath=`@OE_QMAKE_PATH_QT_BINS@/qtpaths --paths ConfigLocation | tr ':' '\n' | sed 's,$,/plasma-workspace,g'`
  
  # Add /env/ to the directory to locate the scripts to be sourced
  for prefix in `echo $scriptpath`; do

--- a/recipes-kde/plasma/tier3/plasma-workspace/files/0007-startplasma.cmake-fix-paths-to-qdbus.patch
+++ b/recipes-kde/plasma/tier3/plasma-workspace/files/0007-startplasma.cmake-fix-paths-to-qdbus.patch
@@ -22,7 +22,7 @@ index 59dc7b7..edd400b 100644
  fi
  
 -qdbus org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit
-+@CMAKE_INSTALL_FULL_BINDIR@/qt5/qdbus org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit
++@OE_QMAKE_PATH_QT_BINS@/qdbus org.kde.KSplash /KSplash org.kde.KSplash.setStage kinit
  
  # finally, give the session control to the session manager
  # see kdebase/ksmserver for the description of the rest of the startup sequence
@@ -31,15 +31,15 @@ index 59dc7b7..edd400b 100644
      wait_drkonqi_timeout=`kreadconfig5 --file startkderc --group WaitForDrKonqi --key Timeout --default 900`
      wait_drkonqi_counter=0
 -    while qdbus | grep "^[^w]*org.kde.drkonqi" > /dev/null ; do
-+    while @CMAKE_INSTALL_FULL_BINDIR@/qt5/qdbus | grep "^[^w]*org.kde.drkonqi" > /dev/null ; do
++    while @OE_QMAKE_PATH_QT_BINS@/qdbus | grep "^[^w]*org.kde.drkonqi" > /dev/null ; do
          sleep 5
          wait_drkonqi_counter=$((wait_drkonqi_counter+5))
          if test "$wait_drkonqi_counter" -ge "$wait_drkonqi_timeout" ; then
              # ask remaining drkonqis to die in a graceful way
 -            qdbus | grep 'org.kde.drkonqi-' | while read address ; do
 -                qdbus "$address" "/MainApplication" "quit"
-+            @CMAKE_INSTALL_FULL_BINDIR@/qt5/qdbus | grep 'org.kde.drkonqi-' | while read address ; do
-+                @CMAKE_INSTALL_FULL_BINDIR@/qt5/qdbus "$address" "/MainApplication" "quit"
++            @OE_QMAKE_PATH_QT_BINS@/qdbus | grep 'org.kde.drkonqi-' | while read address ; do
++                @OE_QMAKE_PATH_QT_BINS@/qdbus "$address" "/MainApplication" "quit"
              done
              break
          fi


### PR DESCRIPTION
Meta-qt5 allows distributions to install qt5 binaries into $bindir
directly. This can be done by overriding QT_DIR_NAME in distribution
config file. Make sure plasma-workspace works in such configurations.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>