### PR TITLE
layer.conf: Add multimedia-layer to LAYERDEPENDS.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,6 +10,6 @@ BBFILE_COLLECTIONS += "meta-qt5-extra"
 BBFILE_PATTERN_meta-qt5-extra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-qt5-extra = "20"
 
-LAYERDEPENDS_meta-qt5-extra = "core qt5-layer openembedded-layer networking-layer"
+LAYERDEPENDS_meta-qt5-extra = "core qt5-layer openembedded-layer networking-layer multimedia-layer"
 
 LICENSE_PATH += "${LAYERDIR}/files/licenses"


### PR DESCRIPTION
Multiple recipes require fluidsynth which is provided by
multimedia-layer.

Signed-off-by: Piotr Tworek <tworaz@tworaz.net>