### PR TITLE
kde-kf5: switch to Attic repository

### DIFF
--- a/classes/kde-kf5-porting-aids.bbclass
+++ b/classes/kde-kf5-porting-aids.bbclass
@@ -1,3 +1,3 @@
 inherit kde-kf5
 
-SRC_URI = "${KDE_MIRROR}/stable/frameworks/5.30/portingAids/${BPN}-${PV}.tar.xz"
+SRC_URI = "${KDE_MIRROR}/Attic/frameworks/5.30/portingAids/${BPN}-${PV}.tar.xz"

--- a/classes/kde-kf5.bbclass
+++ b/classes/kde-kf5.bbclass
@@ -2,4 +2,4 @@ inherit kde-base
 
 KF5_VERSION = "5.30.0"
 
-SRC_URI = "${KDE_MIRROR}/stable/frameworks/5.30/${BPN}-${PV}.tar.xz"
+SRC_URI = "${KDE_MIRROR}/Attic/frameworks/5.30/${BPN}-${PV}.tar.xz"


### PR DESCRIPTION
5.30 version is no more available on stable repository, it has been moved in Attic folder.

Signed-off-by: Simon Desfarges <simon.desfarges@easymile.com>