### PR TITLE
Fix build error and don't force gtk into an image

### DIFF
--- a/recipes-kde/kf5/tier1/kwindowsystem/kwindowsystem.bb
+++ b/recipes-kde/kf5/tier1/kwindowsystem/kwindowsystem.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = " \
 
 inherit kde-kf5 cmake_auto_align_paths cmake_lib
 
-DEPENDS += "${@bb.utils.contains("DISTRO_FEATURES", "x11", "virtual/xserver qtx11extras", "", d)}"
+DEPENDS += "${@bb.utils.contains("DISTRO_FEATURES", "x11", "virtual/xserver qtx11extras libxrender", "", d)}"
 
 PV = "${KF5_VERSION}"
 SRC_URI[md5sum] = "c37711fc60fba6f59e3d12202615384b"

--- a/recipes-lxqt/lxqt-panel/lxqt-panel_git.bb
+++ b/recipes-lxqt/lxqt-panel/lxqt-panel_git.bb
@@ -27,7 +27,7 @@ PACKAGECONFIG[networkmonitor_plugin] = "-DNETWORKMONITOR_PLUGIN=Yes,-DNETWORKMON
 PACKAGECONFIG[sensor_plugin] = "-DSENSORS_PLUGIN=Yes,-DSENSORS_PLUGIN=No, lmsensors"
 PACKAGECONFIG[sysstat_plugin] = "-DSYSSTAT_PLUGIN=Yes,-DSYSSTAT_PLUGIN=No, libsysstat"
 PACKAGECONFIG[volume_alsa_plugin] = "-DVOLUME_USE_ALSA=Yes,-DVOLUME_USE_ALSA=No, alsa-lib"
-PACKAGECONFIG[volume_pulse_plugin] = "-DVOLUME_USE_PULSEAUDIO=Yes,-DVOLUME_USE_PULSEAUDIO=No, pulseaudio, pavucontrol"
+PACKAGECONFIG[volume_pulse_plugin] = "-DVOLUME_USE_PULSEAUDIO=Yes,-DVOLUME_USE_PULSEAUDIO=No, pulseaudio, pavucontrol-qt"
 
 PACKAGECONFIG ??= "cpu_plugin mount_plugin networkmonitor_plugin sensor_plugin sysstat_plugin volume_alsa_plugin volume_pulse_plugin"
 


### PR DESCRIPTION
Hi

This
- fixes a build error with kwindowsystem I get when building a lxqt based image.
- does not erroneously rdepend on gtk+.

Max