### PR TITLE
qt5-translation: improve locale detection

### DIFF
--- a/classes/qt5-translation.bbclass
+++ b/classes/qt5-translation.bbclass
@@ -36,7 +36,7 @@ python qt_do_split_locales() {
         translocation = '%s%s' % (dvar, transvar)
         transfiles = glob.glob(translocation)
         for l in sorted(transfiles):
-            lib, locale = l.replace('.qm', '').split("_",1)
+            lib, locale = os.path.basename(l.replace('.qm', '')).split("_",1)
             if not locale in locales:
                 locales.append(locale)
 


### PR DESCRIPTION
If one path element to ${D} contains a '_' then the logic fails to
split only the locale string. Fix this by first single out only the
file's basename and then split off the locale.

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>