### PR TITLE
aubio: follow waf.bbclass changes

### DIFF
--- a/recipes-misc/recipes-multimedia/aubio/aubio_0.4.6.bb
+++ b/recipes-misc/recipes-multimedia/aubio/aubio_0.4.6.bb
@@ -25,7 +25,7 @@ EXTRA_OECONF = " \
 "
 
 do_compile()  {
-	${S}/waf build ${@get_waf_parallel_make(d)} --notests
+	${S}/waf build ${@oe.utils.parallel_make_argument(d, '-j%d', limit=64)} --notests
 }
 
 do_install() {


### PR DESCRIPTION
oe-core commit ccd1142d22b31ed85d8823b1bc9e11ccfd72b61f
'utils.py: add parallel make helpers'
changed the way one passes the parallel make argument to waf.

prevents:
| bb.data_smart.ExpansionError: Failure expanding variable
| do_compile, expression was
| ...aubio-0.4.6/waf build ${@get_waf_parallel_make(d)} --notests
| which triggered exception
| NameError: name 'get_waf_parallel_make' is not defined

Signed-off-by: Max Krummenacher <max.krummenacher@toradex.com>