### PR TITLE
drumgizmo: remove libsamplerate0 as dependency

### DIFF
--- a/recipes-misc/recipes-multimedia/drumgizmo/drumgizmo.bb
+++ b/recipes-misc/recipes-multimedia/drumgizmo/drumgizmo.bb
@@ -12,7 +12,6 @@ DEPENDS += " \
     libsmf \
     alsa-lib \
     libsndfile1 \
-    libsamplerate0 \
     zita-resampler \
     jack \
 "


### PR DESCRIPTION
As of 0.9.16 this is no longer a dependency.

Signed-off-by: Jonas Suhr Christensen <jsc@umbraculum.org>