### PR TITLE
Updates to lxqt and OE thud

### DIFF
--- a/classes/lxqt.bbclass
+++ b/classes/lxqt.bbclass
@@ -4,7 +4,7 @@ HOMEPAGE = "http://lxqt.org/"
 
 DEPENDS += "lxqt-build-tools qtbase qttools-native"
 
-SRC_URI = "git://github.com/lxde/${BPN}.git;protocol=git;branch=master"
+SRC_URI = "git://github.com/lxqt/${BPN}.git;protocol=git;branch=master"
 S = "${WORKDIR}/git"
 
 EXTRA_OECMAKE += " \

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PATTERN_meta-qt5-extra := "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-qt5-extra = "20"
 
 LAYERDEPENDS_meta-qt5-extra = "core qt5-layer openembedded-layer networking-layer multimedia-layer"
-LAYERSERIES_COMPAT_meta-qt5-extra = "sumo"
+LAYERSERIES_COMPAT_meta-qt5-extra = "sumo thud"
 
 LICENSE_PATH += "${LAYERDIR}/files/licenses"
 

--- a/recipes-lxqt/libfm-qt/libfm-qt_git.bb
+++ b/recipes-lxqt/libfm-qt/libfm-qt_git.bb
@@ -11,8 +11,8 @@ DEPENDS += "qtx11extras glib-2.0 libfm menu-cache libxcb liblxqt"
 CMAKE_ALIGN_FILES_FIND = "*targets.cmake"
 
 SRC_URI += "file://0001-fix-cross-include-path.patch"
-SRCREV = "42c538bd1d4a30a53509ab8b2e8a9437482acbec"
-PV = "0.13.0"
+SRCREV = "422f867a94442fdfe5db06836403b5bc7b5c68db"
+PV = "0.13.1"
 
 FILES_${PN} += "${datadir}/mime"
 


### PR DESCRIPTION
Hi Andreas

LXQt moved to its own github account and there's an update to libfm-qt.
OE-core master now requires thud in LAYERSERIES_COMPAT.

Regards
Max