### PR TITLE
Added kwindowsystem xfixes dependency

### DIFF
--- a/recipes-kde/kf5/tier1/kwindowsystem/kwindowsystem.bb
+++ b/recipes-kde/kf5/tier1/kwindowsystem/kwindowsystem.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = " \
 
 inherit kde-kf5 cmake_auto_align_paths cmake_lib
 
-DEPENDS += "${@bb.utils.contains("DISTRO_FEATURES", "x11", "virtual/libx11 qtx11extras libxrender", "", d)}"
+DEPENDS += "${@bb.utils.contains("DISTRO_FEATURES", "x11", "virtual/libx11 qtx11extras libxrender libxfixes libxfixes-native", "", d)}"
 
 PV = "${KF5_VERSION}"
 SRC_URI[md5sum] = "1c3e335bf029d0da1f4f6b4f9342ae84"


### PR DESCRIPTION
It seems that kwindowsystem needs the xfixes library in the zeus and master branches, other branches have not been tested.

While compiling plasma-mobile, kwindowsystem would break in the `do_configure` step as it could not find the development packages for the `xfixes` library. Adding it as a dependency fixes this issue in the `zeus` and `master` branches. Other branches have not been tested.

I've included both `libxfixes` and `libxfixes-native` but seeing as i'm fairly new to the yocto environment, i'm not sure if both are necessary.