### PR TITLE
Missing Qt5UiPlugin for kplotting

### DIFF
--- a/recipes-kde/kf5/tier1/kplotting/kplotting.bb
+++ b/recipes-kde/kf5/tier1/kplotting/kplotting.bb
@@ -4,6 +4,8 @@ LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=2d5025d4aa3495befef8f17206a5b0a1"
 
 inherit kde-kf5
 
+DEPENDS += "qttools"
+
 PV = "${KF5_VERSION}"
 SRC_URI[md5sum] = "3f405d8c3511d4049f5a93ea66dd0cc8"
 SRC_URI[sha256sum] = "f38f65c97d199077c88213bce84c6162ba254c443f06ccfaf62088ff0e217f7b"


### PR DESCRIPTION
Added dependency of qttools which provides the missing dependency of Qt5UiPlugin.

The error when this is not added on branch `master`:
```
$ bitbake kplotting
NOTE: Started PRServer with DBfile: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/cache/prserv.sqlite3, IP: 127.0.0.1, PORT: 35831, PID: 5405
NOTE: Terminating PRServer...
NOTE: Started PRServer with DBfile: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/cache/prserv.sqlite3, IP: 127.0.0.1, PORT: 38459, PID: 5411
WARNING: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/layers/openembedded-core/bitbake/lib/bb/cache.py:446: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 35831)>  
  value = pickled.load()                                                                     

Loading cache: 100% |#########################################################| Time: 0:00:00
Loaded 4308 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.43.2"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "arm-openstlinux_weston-linux-gnueabi"
MACHINE              = "stm32mp1"
DISTRO               = "openstlinux-weston"
DISTRO_VERSION       = "2.7-snapshot-20191203"
TUNE_FEATURES        = "arm vfp cortexa7 neon vfpv4 thumb callconvention-hard"
TARGET_FPU           = "hard"
DISTRO_CODENAME      = "zeus"
ACCEPT_EULA_stm32mp1 = "1"
GCCVERSION           = "9.%"
PREFERRED_PROVIDER_virtual/kernel = "linux-stm32mp"
meta-python          
meta-oe              
meta-initramfs       
meta-multimedia      
meta-networking      
meta-webserver       
meta-filesystems     
meta-perl            = "master:e0daf6f8e0c53e388c631b8cdf3d7d8173dcea95"
meta-st-stm32mp      = "warrior:8263d32304bfc4cc9a6848c50dcee2a9503dccd7"
meta-qt5             = "master:653e12fdb522c19a7467acb85a77d8b3477671cb"
meta-st-openstlinux  = "warrior:f474d7bf38b2ba3722a76de7b5c1e5da5f319b6e"
meta                 = "master:ccb65286b955d44dacd5fc794851a0c313d116a6"
meta-java            = "master-next:72d32b73861edeed08e9463ceb6e3995f1982be6"
workspace            = "<unknown>:<unknown>"
meta-gud             = "master:1aebe598b818440749d0f936689ffbc2e1e2e8e0"
meta-gnome           = "zeus:aad5b3d070cd8c58828b0975cf861d8ebc90f460"
meta-qt5-extra       = "master:8f4f76403d2216a1c32a1895861b6c50a53725a6"

Initialising tasks: 100% |####################################################| Time: 0:00:00
Sstate summary: Wanted 108 Found 103 Missed 5 Current 930 (95% match, 99% complete)
NOTE: Executing Tasks
NOTE: Setscene tasks completed
ERROR: kplotting-5.63.0-r0 do_configure: Execution of '/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/temp/run.do_configure.6057' failed with exit code 1:
-- The C compiler identification is GNU 9.2.0                                                
-- The CXX compiler identification is GNU 9.2.0                                              
-- Check for working C compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-gcc                                    
-- Check for working C compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-gcc -- works                           
-- Detecting C compiler ABI info                                                             
-- Detecting C compiler ABI info - done                                                      
-- Detecting C compile features                                                              
-- Detecting C compile features - done                                                       
-- Check for working CXX compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-g++                                  
-- Check for working CXX compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-g++ -- works                         
-- Detecting CXX compiler ABI info                                                           
-- Detecting CXX compiler ABI info - done                                                    
-- Detecting CXX compile features                                                            
-- Detecting CXX compile features - done                                                     
--                                                                                           

Installing in /usr. Run /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/prefix.sh to set the environment for KPlotting.      
-- Looking for __GLIBC__                                                                     
-- Looking for __GLIBC__ - found                                                             
-- Performing Test _OFFT_IS_64BIT                                                            
-- Performing Test _OFFT_IS_64BIT - Failed                                                   
-- Performing Test HAVE_DATE_TIME                                                            
-- Performing Test HAVE_DATE_TIME - Success                                                  
-- Could not set up the appstream test. appstreamcli is missing.                             
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY                                            
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success                                  
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY                                     
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success                           
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR                                              
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success                                    
-- The following features have been enabled:                                                 

 * DESIGNERPLUGIN, Build plugin for Qt Designer                                              

-- The following REQUIRED packages have been found:                                          

 * ECM (required version >= 5.63.0), Extra CMake Modules., <https://projects.kde.org/projects/kdesupport/extra-cmake-modules>                                                             
 * Qt5Gui (required version >= 5.13.0)                                                       
 * Qt5Test                                                                                   
 * Qt5Widgets                                                                                
 * Qt5 (required version >= 5.11.0)                                                          

-- The following features have been disabled:                                                

 * QCH, API documentation in QCH format (for e.g. Qt Assistant, Qt Creator & KDevelop)       

-- The following REQUIRED packages have not been found:                                      

 * Qt5UiPlugin                                                                               
   Required to build Qt Designer plugins                                                     

CMake Error at /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/share/cmake-3.15/Modules/FeatureSummary.cmake:457 (message):                                                                           
  feature_summary() Error: REQUIRED package(s) are missing, aborting CMake                   
  run.                                                                                       
Call Stack (most recent call first):                                                         
  CMakeLists.txt:74 (feature_summary)                                                        


-- Configuring incomplete, errors occurred!                                                  
See also "/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/CMakeFiles/CMakeOutput.log".                                       
See also "/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/CMakeFiles/CMakeError.log".                                        
WARNING: exit code 1 from a shell command.                                                   

ERROR: Logfile of failure stored in: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/temp/log.do_configure.6057
Log data follows:
| DEBUG: Executing shell function do_configure
| -- The C compiler identification is GNU 9.2.0
| -- The CXX compiler identification is GNU 9.2.0
| -- Check for working C compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-gcc
| -- Check for working C compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-gcc -- works
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Detecting C compile features
| -- Detecting C compile features - done
| -- Check for working CXX compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-g++
| -- Check for working CXX compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-g++ -- works
| -- Detecting CXX compiler ABI info
| -- Detecting CXX compiler ABI info - done
| -- Detecting CXX compile features
| -- Detecting CXX compile features - done
| --
| 
| Installing in /usr. Run /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/prefix.sh to set the environment for KPlotting.
| -- Looking for __GLIBC__
| -- Looking for __GLIBC__ - found
| -- Performing Test _OFFT_IS_64BIT
| -- Performing Test _OFFT_IS_64BIT - Failed
| -- Performing Test HAVE_DATE_TIME
| -- Performing Test HAVE_DATE_TIME - Success
| -- Could not set up the appstream test. appstreamcli is missing.
| -- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
| -- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
| -- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
| -- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
| -- Performing Test COMPILER_HAS_DEPRECATED_ATTR
| -- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
| -- The following features have been enabled:
| 
|  * DESIGNERPLUGIN, Build plugin for Qt Designer
| 
| -- The following REQUIRED packages have been found:
| 
|  * ECM (required version >= 5.63.0), Extra CMake Modules., <https://projects.kde.org/projects/kdesupport/extra-cmake-modules>
|  * Qt5Gui (required version >= 5.13.0)
|  * Qt5Test
|  * Qt5Widgets
|  * Qt5 (required version >= 5.11.0)
| 
| -- The following features have been disabled:
| 
|  * QCH, API documentation in QCH format (for e.g. Qt Assistant, Qt Creator & KDevelop)
| 
| -- The following REQUIRED packages have not been found:
| 
|  * Qt5UiPlugin
|    Required to build Qt Designer plugins
| 
| CMake Error at /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/share/cmake-3.15/Modules/FeatureSummary.cmake:457 (message):
|   feature_summary() Error: REQUIRED package(s) are missing, aborting CMake
|   run.
| Call Stack (most recent call first):
|   CMakeLists.txt:74 (feature_summary)
| 
| 
| -- Configuring incomplete, errors occurred!
| See also "/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/CMakeFiles/CMakeOutput.log".
| See also "/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/CMakeFiles/CMakeError.log".
| WARNING: exit code 1 from a shell command.
| ERROR: Execution of '/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/temp/run.do_configure.6057' failed with exit code 1:
| -- The C compiler identification is GNU 9.2.0
| -- The CXX compiler identification is GNU 9.2.0
| -- Check for working C compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-gcc
| -- Check for working C compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-gcc -- works
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Detecting C compile features
| -- Detecting C compile features - done
| -- Check for working CXX compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-g++
| -- Check for working CXX compiler: /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/bin/arm-openstlinux_weston-linux-gnueabi/arm-openstlinux_weston-linux-gnueabi-g++ -- works
| -- Detecting CXX compiler ABI info
| -- Detecting CXX compiler ABI info - done
| -- Detecting CXX compile features
| -- Detecting CXX compile features - done
| --
| 
| Installing in /usr. Run /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/prefix.sh to set the environment for KPlotting.
| -- Looking for __GLIBC__
| -- Looking for __GLIBC__ - found
| -- Performing Test _OFFT_IS_64BIT
| -- Performing Test _OFFT_IS_64BIT - Failed
| -- Performing Test HAVE_DATE_TIME
| -- Performing Test HAVE_DATE_TIME - Success
| -- Could not set up the appstream test. appstreamcli is missing.
| -- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
| -- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
| -- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
| -- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
| -- Performing Test COMPILER_HAS_DEPRECATED_ATTR
| -- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
| -- The following features have been enabled:
| 
|  * DESIGNERPLUGIN, Build plugin for Qt Designer
| 
| -- The following REQUIRED packages have been found:
| 
|  * ECM (required version >= 5.63.0), Extra CMake Modules., <https://projects.kde.org/projects/kdesupport/extra-cmake-modules>
|  * Qt5Gui (required version >= 5.13.0)
|  * Qt5Test
|  * Qt5Widgets
|  * Qt5 (required version >= 5.11.0)
| 
| -- The following features have been disabled:
| 
|  * QCH, API documentation in QCH format (for e.g. Qt Assistant, Qt Creator & KDevelop)
| 
| -- The following REQUIRED packages have not been found:
| 
|  * Qt5UiPlugin
|    Required to build Qt Designer plugins
| 
| CMake Error at /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/recipe-sysroot-native/usr/share/cmake-3.15/Modules/FeatureSummary.cmake:457 (message):
|   feature_summary() Error: REQUIRED package(s) are missing, aborting CMake
|   run.
| Call Stack (most recent call first):
|   CMakeLists.txt:74 (feature_summary)
| 
| 
| -- Configuring incomplete, errors occurred!
| See also "/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/CMakeFiles/CMakeOutput.log".
| See also "/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/build-openstlinuxweston-stm32mp1/tmp-glibc/work/cortexa7t2hf-neon-vfpv4-openstlinux_weston-linux-gnueabi/kplotting/5.63.0-r0/build/CMakeFiles/CMakeError.log".
| WARNING: exit code 1 from a shell command.
| 
ERROR: Task (/home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/layers/openembedded-core/meta-qt5-extra/recipes-kde/kf5/tier1/kplotting/kplotting.bb:do_configure) failed with exit code '1'
NOTE: Tasks Summary: Attempted 2712 tasks of which 2706 didn't need to be rerun and 1 failed.
NOTE: Writing buildhistory
NOTE: Writing buildhistory took: 1 seconds

Summary: 1 task failed:
  /home/ns/Documents/stm32/distribution-package/openstlinux-4.19-warrior/layers/openembedded-core/meta-qt5-extra/recipes-kde/kf5/tier1/kplotting/kplotting.bb:do_configure
Summary: There was 1 WARNING message shown.
```