### PR TITLE
fix failure of lxqt-archiver do_compile on dunfell

### DIFF
--- a/recipes-lxqt/lxqt-archiver/0001-fix-compilation-error.patch
+++ b/recipes-lxqt/lxqt-archiver/0001-fix-compilation-error.patch
@@ -1,0 +1,25 @@
+From bec07e42d3446d3a60e7e77586d854fefa093160 Mon Sep 17 00:00:00 2001
+From: Clara Scherer <clara.scherer@avnet.eu>
+Date: Thu, 13 Aug 2020 08:13:46 +0200
+Subject: [PATCH] fix compilation error
+
+---
+ src/core/fr-archive.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/core/fr-archive.c b/src/core/fr-archive.c
+index 75f2309..da089bc 100644
+--- a/src/core/fr-archive.c
++++ b/src/core/fr-archive.c
+@@ -1244,7 +1244,7 @@ copy_remote_file (FrArchive  *archive,
+ 	if (! g_file_query_exists (archive->file, archive->priv->cancellable)) {
+ 		GError *error;
+ 
+-        error = g_error_new (G_IO_ERROR, G_IO_ERROR_NOT_FOUND, _("Archive not found"));
++        error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_NOT_FOUND, _("Archive not found"));
+ 		fr_archive_copy_done (archive, FR_ACTION_LOADING_ARCHIVE, error);
+ 		g_error_free (error);
+ 
+-- 
+2.20.1
+

--- a/recipes-lxqt/lxqt-archiver/lxqt-archiver.bb
+++ b/recipes-lxqt/lxqt-archiver/lxqt-archiver.bb
@@ -11,7 +11,8 @@ DEPENDS += " \
     qtx11extras \
     json-glib \
     libfm-qt \
-"
+
+SRC_URI += "file://0001-fix-compilation-error.patch"
 
 SRCREV = "b6d1ac2cd834edefdb8a754d114da2a89b9323fa"
 PV = "0.2.0"


### PR DESCRIPTION
When building lxqt-archiver in a dunfell Yocto setup, the following error is produced:

```bash
<build-directory>/tmp/work/core2-32-poky-linux/lxqt-archiver/0.2.0-r0/git/src/core/fr-archive.c:1247:9: error: format not a string literal and no format arguments [-Werror=format-security]
 1247 |         error = g_error_new (G_IO_ERROR, G_IO_ERROR_NOT_FOUND, _("Archive not found"));
      |         ^~~~~
```

The patch introduced by this PR fixes the compilation error.