### PR TITLE
Changed SRC_URI to https as ftp source was not available on 2021-05-17

### DIFF
--- a/recipes-support/libstatgrab/libstatgrab_0.91.bb
+++ b/recipes-support/libstatgrab/libstatgrab_0.91.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://www.i-scream.org/libstatgrab/"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-SRC_URI = "ftp://ftp.i-scream.org/pub/i-scream/${BPN}/${BPN}-${PV}.tar.gz"
+SRC_URI = "https://ftp.i-scream.org/pub/i-scream/${BPN}/${BPN}-${PV}.tar.gz"
 SRC_URI[md5sum] = "b906d312076ca9be3d5188edfe07f496"
 SRC_URI[sha256sum] = "03e9328e4857c2c9dcc1b0347724ae4cd741a72ee11acc991784e8ef45b7f1ab"
 


### PR DESCRIPTION
Another option would be to switch to https://github.com/libstatgrab/libstatgrab/releases/download/LIBSTATGRAB_0_91/libstatgrab-0.91.tar.gz

May also be needed for other old branches, but I only checked the recommended branch for Xilinx Petalinux 2019.2