### PR TITLE
avogadrolibs: specify SRCREV_FORMAT

### DIFF
--- a/recipes-misc/recipes-chemistry/avogadro/avogadrolibs.inc
+++ b/recipes-misc/recipes-chemistry/avogadro/avogadrolibs.inc
@@ -8,13 +8,14 @@ inherit cmake_qt5 python3native
 
 PV = "1.97.0"
 SRC_URI = " \
-    git://github.com/OpenChemistry/avogadrolibs.git;branch=master;protocol=https \
+    git://github.com/OpenChemistry/avogadrolibs.git;branch=master;protocol=https;name=avogadrolibs \
     git://github.com/OpenChemistry/molecules;branch=master;protocol=https;name=molecules;destsuffix=molecules \
     git://github.com/OpenChemistry/crystals;branch=master;protocol=https;name=crystals;destsuffix=crystals \
 "
 SRCREV = "82938e4f5ce188a1e53300d263167bebe717f5b2"
 SRCREV_molecules = "b1e16c5dc6d15e72d30dd6c4fca31b2c12025efc"
 SRCREV_crystals = "c3e2468fa42360499f0e73d215bddfe2245258aa"
+SRCREV_FORMAT = "avogadrolibs"
 
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
The avogadrolibs.inc specifies three source repos in its SRC_URI, but does not use SRCREV_FORMAT to declare which is the primary source. As of nanbield, this causes a parse-time error.

```
bb.data_smart.ExpansionError: Failure expanding variable fetcher_hashes_dummyfunc[vardepvalue], expression was ${@bb.fetch.get_hashvalue(d)} which triggered exception FetchError: Fetcher failure: The SRCREV_FORMAT variable must be set when multiple SCMs are used.
```

Assert a valid SRCREV_FORMAT, to avoid this error.

# Testing
* [x] With this patchset, `avogadrolibs-native` now builds without error.
* [x] The work sources look well formed.