### PR TITLE
layer.conf: assert nanbield compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,7 +23,7 @@ LAYERDEPENDS_meta-qt5-extra = " \
     gnome-layer \
     meta-python \
 "
-LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale"
+LAYERSERIES_COMPAT_meta-qt5-extra = "honister kirkstone langdale nanbield"
 
 LICENSE_PATH += "${LAYERDIR}/files/licenses"
 


### PR DESCRIPTION
I'm now using `meta-qt5-extra` with our nanbield-compatible layerstack. The layer parses correctly and all the recipes that I care about from the layer seem to build and function well. It seems like this layer normally asserts compatibility once the OE-core release has been finalized, and nanbield was finalized back in November.

Assert `nanbield` compatibility.