### PR TITLE
solid: Remove buildpaths in preprocessor annotations (2)

### DIFF
--- a/recipes-kde/kf5/tier1/solid/solid.bb
+++ b/recipes-kde/kf5/tier1/solid/solid.bb
@@ -16,9 +16,9 @@ SRC_URI[sha256sum] = "7057825d5de721858af9be698a7114cd45e33bee7c06006a8ec68c05bf
 
 do_install:prepend() {
     # Remove references to buildmachine paths
-    sed -i -e "s:${S}:${prefix}:g" ${B}/src/solid/predicate_parser.h
-    sed -i -e "s:${S}:${prefix}:g" ${B}/src/solid/predicate_parser.c
     sed -i -e "s:${B}:${prefix}:g" ${B}/src/solid/predicate_lexer.c
+    sed -i -e "s:${WORKDIR}::g" ${B}/src/solid/predicate_parser.h
+    sed -i -e "s:${WORKDIR}::g" ${B}/src/solid/predicate_parser.c
 }
 
 


### PR DESCRIPTION
@robwoolley I think this commit extends yours (da181ac2e5f10d67ec3e846e77f1241d0071e057)

Could you please verify? I haven't been able to build the full image (meta-ros desktop) yet, so I haven't tested it.